### PR TITLE
JF: fix map performance

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -74,7 +74,7 @@ const Map = () => {
     } as PointWithProperties;
   });
 
-  const { clusters } = useSupercluster({
+  const { clusters, supercluster } = useSupercluster({
     points,
     bounds,
     zoom,
@@ -133,7 +133,11 @@ const Map = () => {
             strokeColor="blue"
           />
 
-          <ClusteredMarkers clusters={clusters} zoom={zoom} />
+          <ClusteredMarkers
+            clusters={clusters}
+            zoom={zoom}
+            supercluster={supercluster}
+          />
         </MapView>
       </View>
     </View>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,13 +1,14 @@
-import React, { useEffect, useRef, useState } from "react";
-import { View, StyleSheet, Alert } from "react-native";
-import type { Region } from "react-native-maps";
-import MapView, { Circle, PROVIDER_GOOGLE } from "react-native-maps";
-import type { BBox, GeoJsonProperties } from "geojson";
-import type { PointFeature } from "supercluster";
-import useSupercluster from "use-supercluster";
-import MarkerWithWrapper from "@/components/MarkerWithWrapper";
+import ClusteredMarkers from "@/components/ClusteredMarkers";
 import jobs from "@/constants/jobs.json";
 import { SearchJobAdRo } from "@/models";
+import { calculateDeltas, regionToBoundingBox } from "@/utils";
+import type { BBox, GeoJsonProperties } from "geojson";
+import React, { useRef, useState } from "react";
+import { StyleSheet, View } from "react-native";
+import type { Region } from "react-native-maps";
+import MapView, { Circle, PROVIDER_GOOGLE } from "react-native-maps";
+import type { PointFeature } from "supercluster";
+import useSupercluster from "use-supercluster";
 
 export interface PointProperties {
   cluster: boolean;
@@ -25,27 +26,6 @@ const DEFAULT_MAP_LOCATION = {
   lng: 13.2599281,
 };
 
-const calculateDeltas = (latitude: number, radius: number) => {
-  // Earth's radius in kilometers
-  const earthRadius = 6371;
-  // This basically adds empty space around the radius circle
-  // For some reason adding the radius twice works perfectly
-  const additionalCoverage = radius;
-  // Convert distance to radians
-  const distanceRadians = (radius + additionalCoverage) / earthRadius;
-
-  // Calculate latitude delta (1 degree = 111.32 km)
-  const latDelta = distanceRadians * (180 / Math.PI);
-
-  // Calculate longitude delta based on latitude
-  const lonDelta = latDelta / Math.cos((latitude * Math.PI) / 180);
-
-  return {
-    latDelta,
-    lonDelta,
-  };
-};
-
 const Map = () => {
   const mapRef = useRef<MapView>(null);
 
@@ -55,22 +35,6 @@ const Map = () => {
   const latitude = DEFAULT_MAP_LOCATION.lat;
 
   const { latDelta, lonDelta } = calculateDeltas(latitude, 75);
-
-  // TODO: This shouldn't need to be sliced!
-  const searchResultJobAds = jobs.searchJobAds.slice(0, 300);
-
-  const regionToBoundingBox = (region: Region): BBox => {
-    let lngD: number;
-    if (region.longitudeDelta < 0) lngD = region.longitudeDelta + 360;
-    else lngD = region.longitudeDelta;
-
-    return [
-      region.longitude - lngD,
-      region.latitude - region.latitudeDelta,
-      region.longitude + lngD,
-      region.latitude + region.latitudeDelta,
-    ];
-  };
 
   const onRegionChangeComplete = async (region: Region) => {
     const mapBoundsFirst = regionToBoundingBox(region);
@@ -92,7 +56,7 @@ const Map = () => {
     setZoom(camera?.zoom ?? 10);
   };
 
-  const points = searchResultJobAds.map((searchJobAd) => {
+  const points = jobs.searchJobAds.map((searchJobAd) => {
     const loc = searchJobAd.primaryLocation;
 
     return {
@@ -110,7 +74,7 @@ const Map = () => {
     } as PointWithProperties;
   });
 
-  const { clusters, supercluster } = useSupercluster({
+  const { clusters } = useSupercluster({
     points,
     bounds,
     zoom,
@@ -119,25 +83,6 @@ const Map = () => {
       maxZoom: 25,
     },
   });
-
-  function onPointPress() {
-    Alert.alert(`Clicked on point!`);
-  }
-
-  const renderMarkers = () => {
-    console.log(`points: ${points.length}`);
-    return points.map((point) => {
-      return (
-        <MarkerWithWrapper
-          key={point.properties.searchJobAd.combinedId}
-          isSelected={false}
-          onPointPress={onPointPress}
-          point={point}
-          zoom={zoom}
-        ></MarkerWithWrapper>
-      );
-    });
-  };
 
   return (
     <View
@@ -188,7 +133,7 @@ const Map = () => {
             strokeColor="blue"
           />
 
-          {renderMarkers()}
+          <ClusteredMarkers clusters={clusters} zoom={zoom} />
         </MapView>
       </View>
     </View>

--- a/components/ClusteredMarkers/index.tsx
+++ b/components/ClusteredMarkers/index.tsx
@@ -1,10 +1,10 @@
 import { PointProperties, PointWithProperties } from "@/app";
 import React from "react";
-import { Alert, StyleSheet, View, Text } from "react-native";
+import { Alert, StyleSheet, View, Image } from "react-native";
 import { Marker } from "react-native-maps";
 import MarkerWithWrapper from "../MarkerWithWrapper";
 import Supercluster, { PointFeature } from "supercluster";
-
+import { getFirstNonNullMinDim64Url } from "@/utils";
 type Props = {
   clusters: (
     | PointFeature<
@@ -14,13 +14,21 @@ type Props = {
       >
     | PointFeature<Supercluster.ClusterProperties & Supercluster.AnyProps>
   )[];
+  supercluster:
+    | Supercluster<
+        {
+          [name: string]: any;
+        } & PointProperties,
+        Supercluster.AnyProps
+      >
+    | undefined;
   zoom: number;
 };
 
 export default function ClusteredMarkers({
   clusters,
-
   zoom,
+  supercluster,
 }: Props) {
   function onPointPress() {
     Alert.alert(`Clicked on point!`);
@@ -34,7 +42,13 @@ export default function ClusteredMarkers({
       return (
         <Marker key={properties.cluster_id} coordinate={coordinates}>
           <View style={styles.cluster}>
-            <Text style={styles.clusterCount}>{properties.point_count}</Text>
+            <Image
+              style={styles.logo}
+              resizeMode="contain"
+              source={getFirstNonNullMinDim64Url(
+                supercluster?.getLeaves(point.properties.cluster_id)
+              )}
+            />
           </View>
         </Marker>
       );
@@ -54,18 +68,18 @@ export default function ClusteredMarkers({
 
 const styles = StyleSheet.create({
   cluster: {
-    borderRadius: 15,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    borderWidth: 2,
-    borderColor: "blue",
+    width: 40,
+    height: 40,
+    padding: 3,
+    margin: 3,
+    borderRadius: 50,
     backgroundColor: "white",
-    width: 30,
-    height: 30,
+    overflow: "hidden",
+    zIndex: 3,
   },
-  clusterCount: {
-    fontSize: 16,
-    color: "blue",
+  logo: {
+    width: 34,
+    height: 34,
+    borderRadius: 30,
   },
 });

--- a/components/ClusteredMarkers/index.tsx
+++ b/components/ClusteredMarkers/index.tsx
@@ -1,0 +1,71 @@
+import { PointProperties, PointWithProperties } from "@/app";
+import React from "react";
+import { Alert, StyleSheet, View, Text } from "react-native";
+import { Marker } from "react-native-maps";
+import MarkerWithWrapper from "../MarkerWithWrapper";
+import Supercluster, { PointFeature } from "supercluster";
+
+type Props = {
+  clusters: (
+    | PointFeature<
+        {
+          [name: string]: any;
+        } & PointProperties
+      >
+    | PointFeature<Supercluster.ClusterProperties & Supercluster.AnyProps>
+  )[];
+  zoom: number;
+};
+
+export default function ClusteredMarkers({
+  clusters,
+
+  zoom,
+}: Props) {
+  function onPointPress() {
+    Alert.alert(`Clicked on point!`);
+  }
+  return clusters?.map((point) => {
+    const [longitude, latitude] = point.geometry.coordinates;
+    const coordinates = { latitude, longitude };
+    const properties = point.properties;
+
+    if (properties?.cluster) {
+      return (
+        <Marker key={properties.cluster_id} coordinate={coordinates}>
+          <View style={styles.cluster}>
+            <Text style={styles.clusterCount}>{properties.point_count}</Text>
+          </View>
+        </Marker>
+      );
+    }
+
+    return (
+      <MarkerWithWrapper
+        key={point.properties.searchJobAd.combinedId}
+        isSelected={false}
+        onPointPress={onPointPress}
+        point={point as PointWithProperties}
+        zoom={zoom}
+      />
+    );
+  });
+}
+
+const styles = StyleSheet.create({
+  cluster: {
+    borderRadius: 15,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 2,
+    borderColor: "blue",
+    backgroundColor: "white",
+    width: 30,
+    height: 30,
+  },
+  clusterCount: {
+    fontSize: 16,
+    color: "blue",
+  },
+});

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,2 +1,1 @@
-export { CenterJobPointActivater } from './CenterJobPointActivater';
-export { PointsToRenderCalculator } from './PointsToRenderCalculator';
+export * from "./mapsUtils";

--- a/utils/mapsUtils.ts
+++ b/utils/mapsUtils.ts
@@ -1,0 +1,36 @@
+import type { Region } from "react-native-maps";
+import type { BBox } from "geojson";
+
+export const calculateDeltas = (latitude: number, radius: number) => {
+  // Earth's radius in kilometers
+  const earthRadius = 6371;
+  // This basically adds empty space around the radius circle
+  // For some reason adding the radius twice works perfectly
+  const additionalCoverage = radius;
+  // Convert distance to radians
+  const distanceRadians = (radius + additionalCoverage) / earthRadius;
+
+  // Calculate latitude delta (1 degree = 111.32 km)
+  const latDelta = distanceRadians * (180 / Math.PI);
+
+  // Calculate longitude delta based on latitude
+  const lonDelta = latDelta / Math.cos((latitude * Math.PI) / 180);
+
+  return {
+    latDelta,
+    lonDelta,
+  };
+};
+
+export const regionToBoundingBox = (region: Region): BBox => {
+  let lngD: number;
+  if (region.longitudeDelta < 0) lngD = region.longitudeDelta + 360;
+  else lngD = region.longitudeDelta;
+
+  return [
+    region.longitude - lngD,
+    region.latitude - region.latitudeDelta,
+    region.longitude + lngD,
+    region.latitude + region.latitudeDelta,
+  ];
+};

--- a/utils/mapsUtils.ts
+++ b/utils/mapsUtils.ts
@@ -1,5 +1,8 @@
 import type { Region } from "react-native-maps";
 import type { BBox } from "geojson";
+import Supercluster from "supercluster";
+import { PointProperties } from "@/app";
+const logo = require("@/assets/images/company-placeholder-128.jpg");
 
 export const calculateDeltas = (latitude: number, radius: number) => {
   // Earth's radius in kilometers
@@ -33,4 +36,16 @@ export const regionToBoundingBox = (region: Region): BBox => {
     region.longitude + lngD,
     region.latitude + region.latitudeDelta,
   ];
+};
+
+export const getFirstNonNullMinDim64Url = (
+  cluster?: Array<Supercluster.PointFeature<PointProperties>>
+) => {
+  if (!cluster) return logo;
+  for (let point of cluster) {
+    const uri =
+      point.properties.job?.company?.logoImg?.variants?.min_dim_64_url;
+    if (uri) return { uri };
+  }
+  return logo;
 };


### PR DESCRIPTION
## Description
- Enhance map poor performance upon loading multiple markers

## Time Track

- Started working on it on Tuesday afternoon and finished the first solution by the evening.

## Test

- Before pulling try out the map on the main branch, open the performance monitor and check the js and ui threads fps
- checkout out this branch
- check the performance monitor, it gets 60 fps all the time

## Screenshots

<img width="391" alt="Screenshot 2024-05-14 at 8 20 10 PM" src="https://github.com/Jobflow-io/jobflow-map-challenge/assets/42500364/16f8ce14-6392-4663-bea0-485d22ea9236">

**Edit**: for now we can show the image of company as cluster image and once zoom in the group is going to be shown

https://github.com/Jobflow-io/jobflow-map-challenge/assets/42500364/98ad21a0-62d7-42ef-ac87-900c701e098b

**PS**: we can further improve the performance by setting the `tracksViewChanges` to `false` as here it will work because of conditional rendering by the supercluster but one downside to it is that the image will be shown as white until it loads but there will be no flicker. This has the best performance until now ( did not push this,  just disable the `tracksViewChanges`)


https://github.com/Jobflow-io/jobflow-map-challenge/assets/42500364/fb39ad5e-088b-441a-b1c8-8336fa9795e8



## Notes

- **Sol 1**: this solution uses clustering, I used only the installed library use-supercluster (found another that simplifies react-native-maps-clustering but no need for extra bundle size)

- **Sol 2**: tried out to only show the markers that appear inside the bounding box (we can simplify getting it using predefined react native maps method: `getBounds`), but the problem persisted as almost all the markers are scattered in the same area: I didn't want to change the data as I assumed that this is a real scenario as stated in the challenge.

- **Sol 3**: tried setting the `tracksViewChanges` to `false` and re-render the marker custom image using the `redraw` method but got no luck on ios as the redraw was not called either inside `onLoad` or when using an effect.

- **Sol 4**: I am thinking of creating a small server and will try to send data by chunks but I thought that the map will flicker a bit as if I set the `tracksViewChanges` to `false` I need to force a re-render.

**PS**: I think we can overcome the **Sol 3** issue with further investigation, will keep trying for it and once done will create another PR for it. Also will try **Sol 4** after that.

