### PR TITLE
fix: redraw markers manually

### DIFF
--- a/components/Marker/index.tsx
+++ b/components/Marker/index.tsx
@@ -1,13 +1,23 @@
-import React from "react";
-import { Image, Text, View } from "react-native";
+import React, { Dispatch } from "react";
+import { Image, Platform, View } from "react-native";
 
+import { MapMarker } from "react-native-maps";
 import styles from "./styles";
 
 interface Props {
   companyLogo: string | null;
+  update: Dispatch<React.SetStateAction<boolean>>;
+  markerRef: React.RefObject<MapMarker>;
 }
 
-export const Marker = ({ companyLogo }: Props) => {
+export const Marker = ({ companyLogo, markerRef, update }: Props) => {
+  const onLoadEnd = () => {
+    if (Platform.OS === "android") {
+      markerRef.current?.redraw();
+    } else {
+      update(false);
+    }
+  };
   return (
     <View
       style={[
@@ -23,6 +33,8 @@ export const Marker = ({ companyLogo }: Props) => {
           style={[styles.logo]}
           resizeMode="contain"
           source={{ uri: companyLogo }}
+          onLoadEnd={onLoadEnd}
+          fadeDuration={0}
         />
       ) : (
         <Image

--- a/components/MarkerWithWrapper/index.tsx
+++ b/components/MarkerWithWrapper/index.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from "react";
+import { useRef, useState } from "react";
 import type { MapMarker } from "react-native-maps";
 import { Marker } from "react-native-maps";
 import { Marker as MarkerMap } from "@/components/Marker";
 
 import { PointWithProperties } from "@/app";
+import { Platform } from "react-native";
 
 type Props = {
   point: PointWithProperties;
@@ -18,6 +19,7 @@ export default function MarkerWithWrapper({
   zoom,
   isSelected,
 }: Props) {
+  const [shouldTrack, setShouldTrack] = useState(true);
   const coordinates = point.geometry.coordinates;
   const markerRef = useRef<MapMarker>(null);
 
@@ -29,7 +31,7 @@ export default function MarkerWithWrapper({
   return (
     <Marker
       ref={markerRef}
-      tracksViewChanges={true}
+      tracksViewChanges={Platform.OS === "android" ? false : shouldTrack}
       coordinate={{
         latitude: lat,
         longitude: lng,
@@ -37,6 +39,8 @@ export default function MarkerWithWrapper({
       onPress={() => onPointPress()}
     >
       <MarkerMap
+        update={setShouldTrack}
+        markerRef={markerRef}
         companyLogo={job.company.logoImg?.variants.min_dim_64_url ?? null}
       />
     </Marker>


### PR DESCRIPTION
## Description
- Enhance map poor performance upon loading multiple markers solution 2

## Test

- Before pulling try out the map on the main branch, open the performance monitor and check the js and ui threads fps
- checkout out this branch
- check the performance monitor, it gets 60 fps all the time for Android and ios gets to 60fps on loading the markers

## Screenshots

https://github.com/Jobflow-io/jobflow-map-challenge/assets/42500364/d6690dba-55af-4f74-bdc8-e072c90b462a


https://github.com/Jobflow-io/jobflow-map-challenge/assets/42500364/a2c5e121-7322-4155-a6d1-d17bb8c90d23



## Idea

- On **Android**: set track changes to false always and once the custom image was loaded we force a marker re-render using the redraw function
- On **IOS**: the redraw doesn't work properly so to overcome this, we use a state to update the `tracksViewChanges` to `false` once the image is loaded

The problem with this approach is that on Android the markers appear "suddenly" and on IOS the performance starts slow and with every image load it flickers as we re-render. I think we can overcome this we can use an Animated marker so it appears smoothly.

Also we can reduce the number of re-renders by making a global state and once all images with uri are loaded we update that state (used for `tracksViewChanges` value). But this requires extra work as we need to follow every network request status as some of them may fail so we can count those as success to update our state in the end

