### PR TITLE
Fix: map performance sol3

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { View, StyleSheet, Alert } from "react-native";
 import type { Region } from "react-native-maps";
 import MapView, { Circle, PROVIDER_GOOGLE } from "react-native-maps";
@@ -8,6 +8,7 @@ import useSupercluster from "use-supercluster";
 import MarkerWithWrapper from "@/components/MarkerWithWrapper";
 import jobs from "@/constants/jobs.json";
 import { SearchJobAdRo } from "@/models";
+import useTrackChanges from "@/hooks/useTrackChanges";
 
 export interface PointProperties {
   cluster: boolean;
@@ -120,6 +121,7 @@ const Map = () => {
     },
   });
 
+  const { renderCount, shouldTrack } = useTrackChanges(points);
   function onPointPress() {
     Alert.alert(`Clicked on point!`);
   }
@@ -134,6 +136,8 @@ const Map = () => {
           onPointPress={onPointPress}
           point={point}
           zoom={zoom}
+          shouldTrack={shouldTrack}
+          renderCount={renderCount}
         ></MarkerWithWrapper>
       );
     });

--- a/components/Marker/index.tsx
+++ b/components/Marker/index.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch } from "react";
+import React, { Dispatch, MutableRefObject } from "react";
 import { Image, Platform, View } from "react-native";
 
 import { MapMarker } from "react-native-maps";
@@ -6,17 +6,16 @@ import styles from "./styles";
 
 interface Props {
   companyLogo: string | null;
-  update: Dispatch<React.SetStateAction<boolean>>;
-  markerRef: React.RefObject<MapMarker>;
+  renderCount: MutableRefObject<number>;
 }
 
-export const Marker = ({ companyLogo, markerRef, update }: Props) => {
+export const Marker = ({ companyLogo, renderCount }: Props) => {
   const onLoadEnd = () => {
-    if (Platform.OS === "android") {
-      markerRef.current?.redraw();
-    } else {
-      update(false);
-    }
+    renderCount.current++;
+  };
+
+  const onError = () => {
+    renderCount.current++;
   };
   return (
     <View
@@ -35,6 +34,7 @@ export const Marker = ({ companyLogo, markerRef, update }: Props) => {
           source={{ uri: companyLogo }}
           onLoadEnd={onLoadEnd}
           fadeDuration={0}
+          onError={onError}
         />
       ) : (
         <Image

--- a/components/Marker/index.tsx
+++ b/components/Marker/index.tsx
@@ -1,13 +1,23 @@
-import React from "react";
-import { Image, Text, View } from "react-native";
+import React, { Dispatch } from "react";
+import { Image, Platform, View } from "react-native";
 
+import { MapMarker } from "react-native-maps";
 import styles from "./styles";
 
 interface Props {
   companyLogo: string | null;
+  update: Dispatch<React.SetStateAction<boolean>>;
+  markerRef: React.RefObject<MapMarker>;
 }
 
-export const Marker = ({ companyLogo }: Props) => {
+export const Marker = ({ companyLogo, markerRef, update }: Props) => {
+  const onLoadEnd = () => {
+    if (Platform.OS === "android") {
+      markerRef.current?.redraw();
+    } else {
+      update(false);
+    }
+  };
   return (
     <View
       style={[
@@ -23,6 +33,8 @@ export const Marker = ({ companyLogo }: Props) => {
           style={[styles.logo]}
           resizeMode="contain"
           source={{ uri: companyLogo }}
+          onLoadEnd={onLoadEnd}
+          fadeDuration={0}
         />
       ) : (
         <Image

--- a/components/MarkerWithWrapper/index.tsx
+++ b/components/MarkerWithWrapper/index.tsx
@@ -1,25 +1,26 @@
-import { useRef, useState } from "react";
+import { MutableRefObject, useRef } from "react";
 import type { MapMarker } from "react-native-maps";
 import { Marker } from "react-native-maps";
 import { Marker as MarkerMap } from "@/components/Marker";
 
 import { PointWithProperties } from "@/app";
-import { Platform } from "react-native";
 
 type Props = {
   point: PointWithProperties;
   onPointPress: () => void;
   isSelected: boolean;
   zoom: number;
+
+  shouldTrack: boolean;
+  renderCount: MutableRefObject<number>;
 };
 
 export default function MarkerWithWrapper({
   point,
   onPointPress,
-  zoom,
-  isSelected,
+  shouldTrack,
+  renderCount,
 }: Props) {
-  const [shouldTrack, setShouldTrack] = useState(true);
   const coordinates = point.geometry.coordinates;
   const markerRef = useRef<MapMarker>(null);
 
@@ -31,7 +32,7 @@ export default function MarkerWithWrapper({
   return (
     <Marker
       ref={markerRef}
-      tracksViewChanges={Platform.OS === "android" ? false : shouldTrack}
+      tracksViewChanges={shouldTrack}
       coordinate={{
         latitude: lat,
         longitude: lng,
@@ -39,9 +40,8 @@ export default function MarkerWithWrapper({
       onPress={() => onPointPress()}
     >
       <MarkerMap
-        update={setShouldTrack}
-        markerRef={markerRef}
         companyLogo={job.company.logoImg?.variants.min_dim_64_url ?? null}
+        renderCount={renderCount}
       />
     </Marker>
   );

--- a/components/MarkerWithWrapper/index.tsx
+++ b/components/MarkerWithWrapper/index.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from "react";
+import { useRef, useState } from "react";
 import type { MapMarker } from "react-native-maps";
 import { Marker } from "react-native-maps";
 import { Marker as MarkerMap } from "@/components/Marker";
 
 import { PointWithProperties } from "@/app";
+import { Platform } from "react-native";
 
 type Props = {
   point: PointWithProperties;
@@ -18,6 +19,7 @@ export default function MarkerWithWrapper({
   zoom,
   isSelected,
 }: Props) {
+  const [shouldTrack, setShouldTrack] = useState(true);
   const coordinates = point.geometry.coordinates;
   const markerRef = useRef<MapMarker>(null);
 
@@ -29,7 +31,7 @@ export default function MarkerWithWrapper({
   return (
     <Marker
       ref={markerRef}
-      tracksViewChanges={true}
+      tracksViewChanges={Platform.OS === "android" ? false : shouldTrack}
       coordinate={{
         latitude: lat,
         longitude: lng,
@@ -37,6 +39,8 @@ export default function MarkerWithWrapper({
       onPress={() => onPointPress()}
     >
       <MarkerMap
+        update={setShouldTrack}
+        markerRef={markerRef}
         companyLogo={job.company.logoImg?.variants.min_dim_64_url ?? null}
       />
     </Marker>

--- a/hooks/useTrackChanges.tsx
+++ b/hooks/useTrackChanges.tsx
@@ -1,0 +1,20 @@
+import { PointWithProperties } from "@/app";
+import { countNonNullMinDim64Urls } from "@/utils/map";
+import React, { useEffect, useRef, useState } from "react";
+
+export default function useTrackChanges(points: PointWithProperties[]) {
+  const renderCount = useRef(0);
+
+  const [shouldTrack, setShouldTrack] = useState(true);
+  useEffect(() => {
+    const nonNullURI = countNonNullMinDim64Urls(points);
+    if (nonNullURI <= renderCount.current) {
+      setShouldTrack(false);
+    }
+  }, [renderCount.current]);
+
+  return {
+    shouldTrack,
+    renderCount,
+  };
+}

--- a/utils/map.ts
+++ b/utils/map.ts
@@ -1,0 +1,12 @@
+import { PointWithProperties } from "@/app";
+
+export function countNonNullMinDim64Urls(points: PointWithProperties[]) {
+  let count = 0;
+  for (let obj of points) {
+    const url = obj.properties.job?.company?.logoImg?.variants?.min_dim_64_url;
+    if (url) {
+      count++;
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
## Description
- Enhance map poor performance upon loading multiple markers solution 2

## Test

- Before pulling try out the map on the main branch, open the performance monitor and check the js and ui threads fps
- checkout out this branch
- check the performance monitor, it gets 60 fps all the time for Android and ios gets to 60fps on loading the markers

## Idea

this solution is only destined for ios ( android was fixed on the second solution), in this one the idea to keep track of the images if there network request is done and after that we disable the `tracksViewChanges`. The tracking is happened using ref so no re-render cost.